### PR TITLE
makefile and util scrips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 libptmallocdump.so
+glibc_main_arena_address

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+libptmallocdump.so

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ RM      = rm -f
 DUMPER_SRC = ptmallocdump.c
 DUMPER_LIB = libptmallocdump.so
 
-TARGETS = $(DUMPER_LIB)
+GLIBC_MAIN_ARENA_CACHE = glibc_main_arena_address
+
+TARGETS = $(DUMPER_LIB) $(GLIBC_MAIN_ARENA_CACHE)
 
 
 all: build
@@ -15,6 +17,9 @@ build: $(TARGETS)
 
 $(DUMPER_LIB): $(DUMPER_SRC)
 	$(CC) $(CFLAGS) -shared $^ $(LDFLAGS) -o $@
+
+$(GLIBC_MAIN_ARENA_CACHE): $(DUMPER_LIB)
+	./find_main_arena.sh > $@
 
 clean:
 	@for file in $(TARGETS) ; do \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+
+CFLAGS  = -g -fPIC -DPIC -Wall -fno-strict-aliasing
+LDFLAGS =
+CC      = gcc -std=c99
+RM      = rm -f
+
+DUMPER_SRC = ptmallocdump.c
+DUMPER_LIB = libptmallocdump.so
+
+TARGETS = $(DUMPER_LIB)
+
+
+all: build
+build: $(TARGETS)
+
+$(DUMPER_LIB): $(DUMPER_SRC)
+	$(CC) $(CFLAGS) -shared $^ $(LDFLAGS) -o $@
+
+clean:
+	@for file in $(TARGETS) ; do \
+	    if test -f "$$file" ; then \
+	        echo "$(RM) \"$$file\"" ; \
+	        $(RM) "$$file" ; \
+	    fi ; \
+	done
+
+.PHONY: all build clean

--- a/find_glibc_mapping.sh
+++ b/find_glibc_mapping.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+die() {
+    echo "$0: ERROR - $*" 1>&2
+    exit 1
+}
+
+show_usage() {
+    echo "Usage: $0 [options] <pid>"
+    echo
+    echo "OPTIONS"
+    echo "    -a, --add OFFSET  Add the given hexidecimal offset"
+    echo "                        to the mapped base address."
+}
+
+if test $# -lt 1 ; then
+    show_usage
+    exit 1
+fi
+
+mode=print
+offset=0
+
+if type getopt 2>&1 >/dev/null ; then
+    # have GNU getopt (allows nicer options)
+    SOPT="ha:"
+    LOPT="help,add:"
+    OPTIONS=$(getopt -o "$SOPT" --long "$LOPT" -n "$0" -- "$@") || exit 1
+    eval set -- "$OPTIONS"
+fi
+
+while true ; do
+    case "$1" in
+        -h | --help)  show_usage ;  exit 0 ;;
+        -a | --add)   mode=add ; offset=$2 ; shift 2 ;;
+        --) shift ; break ;;
+        -*) die "bad opt: $1" ;;
+        *) break ;;
+    esac
+done
+
+pid=$1
+
+find_mapping_addr() {
+    grep '/libc-[0-9.]*\.so$' /proc/${pid}/maps |
+        grep ' r-xp ' |
+        cut -d- -f 1
+}
+
+mapping_addr="$(find_mapping_addr)"
+
+sum_base_and_offset() {
+    echo "ibase = 16; obase = 10; ${offset} + ${mapping_addr}" | bc
+}
+
+case $mode in
+    print) echo "${mapping_addr}"        ;;
+    add)   sum_base_and_offset           ;;
+    *)     die "not a mode: \"${mode}\"" ;;
+esac

--- a/find_main_arena.sh
+++ b/find_main_arena.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+DEBUG_FILE_DIR="/usr/lib/debug"
+
+die() {
+    echo "$0: ERROR - $*" 1>&2
+    exit 1
+}
+
+DUMPER_LIB="$( grep ^DUMPER_LIB Makefile | awk '{ print $3 }' )"
+if ! test -f "${DUMPER_LIB}" ; then
+    die "missing DUMPER_LIB (\"${DUMPER_LIB}\")"
+fi
+
+libc_soname_path() {
+    ldd "${DUMPER_LIB}" |
+        tr -d '\t'      |
+        grep ^libc.so.6  |
+        awk '{ print $3 }'
+}
+
+real_libc_path="$( readlink -e "$(libc_soname_path)" )"
+libc_debug_path="${DEBUG_FILE_DIR}/${real_libc_path}.debug"
+
+if ! test -f "${libc_debug_path}" ; then
+    die "missing libc debug symbols \"${libc_debug_path}\""
+fi
+
+objdump -t "${libc_debug_path}" | grep ' main_arena' | awk '{ print $1 }'

--- a/find_main_arena.sh
+++ b/find_main_arena.sh
@@ -26,4 +26,7 @@ if ! test -f "${libc_debug_path}" ; then
     die "missing libc debug symbols \"${libc_debug_path}\""
 fi
 
-objdump -t "${libc_debug_path}" | grep ' main_arena' | awk '{ print $1 }'
+objdump -t "${libc_debug_path}" |
+    grep ' main_arena' |
+    awk '{ print $1 }' |
+    tr 'a-f' 'A-F'

--- a/ptmallocdump.c
+++ b/ptmallocdump.c
@@ -1,5 +1,3 @@
-// gcc -shared -g ptmallocdump.c -fPIC -o libptmallocdump.so -Wall -fno-strict-aliasing
-
 #include <stddef.h>
 #include <stdio.h>
 #include <stdint.h>


### PR DESCRIPTION
I added a basic Makefile and a couple shell scripts that attempt to automate finding the glibc mapping address.

The Makefile uses find_main_arena.sh to cache libc's main_arena offset in a file. find_glibc_mapping.sh is mostly your command to pull the base address out of /proc that can optionally add a given offset.

The next step is probably some sort of integration of `./find_glibc_mapping.sh -a $(cat glibc_main_arena_address) $PID` into e.g. your `module PtmallocDumper` to automate part of the dumping process?